### PR TITLE
added perfit error handler to instument number of errors per second

### DIFF
--- a/src/PerfIt.WebApi/PerfItFilterAttribute.cs
+++ b/src/PerfIt.WebApi/PerfItFilterAttribute.cs
@@ -157,7 +157,11 @@ namespace PerfIt.WebApi
 
                 if (actionExecutedContext.Request.Properties.ContainsKey(PerfItTwoStageKey))
                 {
-                    var token = actionExecutedContext.Request.Properties[PerfItTwoStageKey];
+                    var token = actionExecutedContext.Request.Properties[PerfItTwoStageKey] as InstrumentationToken;
+                    if (actionExecutedContext.Exception != null && token != null)
+                    {
+                        token.Contexts.Item2.SetContextToErrorState();
+                    }
                     _instrumentor.Finish(token, instrumentationContext);
                 }
             }

--- a/src/PerfIt/Constants.cs
+++ b/src/PerfIt/Constants.cs
@@ -9,6 +9,7 @@ namespace PerfIt
     {
         public const string PerfItKey = "_#_PerfIt_#_";
         public const string PerfItPublishErrorsKey = "_#_PerfIt_Publish_Error_#_";
+        public const string PerfItContextHasErroredKey = "_#_PerfIt_Has_Error_#_";
         public const string PerfItInstrumentationContextKey = "_#_PerfIt_Instrumentation_Context_#_";
         public const string PerfItInstanceNameKey = "_#_PerfIt_Instance_Name_#_";
         public const string PerfItPublishCounters = "perfit:publishCounters";

--- a/src/PerfIt/CounterTypes.cs
+++ b/src/PerfIt/CounterTypes.cs
@@ -11,6 +11,7 @@ namespace PerfIt
         public const string TotalNoOfOperations = "TotalNoOfOperations";
         public const string LastOperationExecutionTime = "LastOperationExecutionTime";
         public const string NumberOfOperationsPerSecond = "NumberOfOperationsPerSecond";
+        public const string NumberOfErrorsPerSecond = "NumberOfErrorsPerSecond";
         public const string CurrentConcurrentOperationsCount = "CurrentConcurrentOperationsCount";
 
         public static readonly string[] StandardCounters = new[]
@@ -19,6 +20,7 @@ namespace PerfIt
             TotalNoOfOperations,
             LastOperationExecutionTime,
             NumberOfOperationsPerSecond,
+            NumberOfErrorsPerSecond,
             CurrentConcurrentOperationsCount
         };
 

--- a/src/PerfIt/Handlers/NumberOfErrorsPerSecondHandler.cs
+++ b/src/PerfIt/Handlers/NumberOfErrorsPerSecondHandler.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace PerfIt.Handlers
+{
+    public class NumberOfErrorsPerSecondHandler : CounterHandlerBase
+    {
+        private Lazy<PerformanceCounter> _counter;
+        private const string TimeTakenTicksKey = "NumberOfOperationsPerErrorsHandler_#_StopWatch_#_";
+
+        public NumberOfErrorsPerSecondHandler
+            (
+            string categoryName,
+            string instanceName)
+            : base(categoryName, instanceName)
+        {
+           BuildCounters();
+        }
+
+        public override string CounterType
+        {
+            get { return CounterTypes.NumberOfErrorsPerSecond; }
+        }
+
+        protected override void OnRequestStarting(IDictionary<string, object> contextBag, PerfItContext context)
+        {
+        }
+
+        protected override void OnRequestEnding(IDictionary<string, object> contextBag, PerfItContext context)
+        {
+            if (contextBag.ContainsKey(Constants.PerfItContextHasErroredKey))
+            {
+                _counter.Value.Increment();
+            }
+        }
+
+        protected override void BuildCounters(bool newInstanceName = false)
+        {
+            _counter = new Lazy<PerformanceCounter>(() =>
+            {
+                var counter = new PerformanceCounter()
+                {
+                    CategoryName = _categoryName,
+                    CounterName = Name,
+                    InstanceName = GetInstanceName(newInstanceName),
+                    ReadOnly = false,
+                    InstanceLifetime = PerformanceCounterInstanceLifetime.Process
+                };
+                counter.RawValue = 0;
+                return counter;
+            });
+        }
+
+        protected override CounterCreationData[] DoGetCreationData()
+        {
+            var counterCreationDatas = new CounterCreationData[1];
+            counterCreationDatas[0] = new CounterCreationData()
+            {
+                CounterType = PerformanceCounterType.RateOfCountsPerSecond32,
+                CounterName = Name,
+                CounterHelp = "# of error operations / sec"
+            };
+
+            return counterCreationDatas;
+        }
+    }
+}

--- a/src/PerfIt/ITwoStageInstrumentor.cs
+++ b/src/PerfIt/ITwoStageInstrumentor.cs
@@ -9,7 +9,7 @@ namespace PerfIt
     public interface ITwoStageInstrumentor
     {
         object Start();
-
+        
         void Finish(object token, string instrumentationContext = null);
     }
 }

--- a/src/PerfIt/InstrumentationToken.cs
+++ b/src/PerfIt/InstrumentationToken.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace PerfIt
+{
+    public class InstrumentationToken
+    {
+        public Tuple<IEnumerable<PerfitHandlerContext>, Dictionary<string, object>> Contexts { get; set; }
+
+        public Stopwatch Kronometer { get; set; }
+    }
+}

--- a/src/PerfIt/PerfIt.csproj
+++ b/src/PerfIt/PerfIt.csproj
@@ -47,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Handlers\CurrentConcurrentCountHandler.cs" />
+    <Compile Include="Handlers\NumberOfErrorsPerSecondHandler.cs" />
     <Compile Include="Handlers\NumberOfOperationsPerSecondHandler.cs" />
     <Compile Include="IInstrumentationDiscoverer.cs" />
     <Compile Include="IInstrumentationInfo.cs" />
@@ -65,6 +66,8 @@
     <Compile Include="PerfitHandlerContext.cs" />
     <Compile Include="PerfItRuntime.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PerfItExtensions.cs" />
+    <Compile Include="InstrumentationToken.cs" />
     <Compile Include="SimpleInstrumentor.cs" />
   </ItemGroup>
   <ItemGroup />

--- a/src/PerfIt/PerfItRuntime.cs
+++ b/src/PerfIt/PerfItRuntime.cs
@@ -32,6 +32,9 @@ namespace PerfIt
             HandlerFactories.Add(CounterTypes.CurrentConcurrentOperationsCount,
                 (categoryName, instanceName) => new CurrentConcurrentCountHandler(categoryName, instanceName));
 
+            HandlerFactories.Add(CounterTypes.NumberOfErrorsPerSecond,
+                (categoryName, instanceName) => new NumberOfErrorsPerSecondHandler(categoryName, instanceName));
+
         }
 
         /// <summary>

--- a/src/PerfIt/PerfitExtensions.cs
+++ b/src/PerfIt/PerfitExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace PerfIt
+{
+    public static class PerfItExtensions 
+    {
+       public static void SetContextToErrorState(this Dictionary<string, object> contexts)
+        {
+            contexts[Constants.PerfItContextHasErroredKey] = true;
+        }
+        
+    }
+}


### PR DESCRIPTION
Hi Ali, could you take a look at the below, ive updated perfit to create a new counter for the number of errors per second for a particular action.  I've update the SimpleInstrumentor and PerfitFilter in the web api project (if theres an error they add a flag into the context and the counter then acts on this if it is present.

It works correctly in all but the perfit async interceptor (the catch is never called, but i think this is an issue with how the interceptor calls the async invocation).