### PR TITLE
Remove Guid, fix typo and change to allowed seperator character

### DIFF
--- a/src/PerfIt/InstrumentationEventSource.cs
+++ b/src/PerfIt/InstrumentationEventSource.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace PerfIt
 {
-    [EventSource(Name = "PerIt!Instrumentation", Guid = "{010380F8-40A7-45C3-B87B-FD4C6CC8700A}")]
+    [EventSource(Name = "PerfIt-Instrumentation")]
     public class InstrumentationEventSource : EventSource
     {
         public static readonly InstrumentationEventSource Instance = new InstrumentationEventSource();


### PR DESCRIPTION
I was unable to get the InstrumentationEventSource logs to be collected by the Azure Diagnostics EtwProvider. While investigating I came across the following issues.

From the EventSourceAttribute [msdn](https://msdn.microsoft.com/en-us/library/system.diagnostics.tracing.eventsourceattribute):

> The EventSourceAttribute attribute also lets you define a GUID explicitly for the event source. In standard usage, you don’t need to specify a GUID when defining an event source or referring to it, because a GUID is implicitly derived from the name of the event source class. Explicitly defining a GUID is discouraged, except when upgrading existing ETW providers to using event sources.

I also discovered that the `!` in `PerIt!Instrumentation` was causing issues with ETW matching on the name. Removing the character or replacing it with `-` seems to fix the issue. Microsoft are keen on using the `-` character [here](https://github.com/Microsoft/dotnetsamples/blob/master/Microsoft.Diagnostics.Tracing/EventSource/docs/EventSource.md) so it might be good to standardise on that.

With the above two fixes it is possible to use the standard Azure Diagnostics Etw table storage collectors with PerfIt! 😄