### PR TITLE
Only call handlers for counters specified in SimpleInstrumentor constructor

### DIFF
--- a/src/PerfIt/SimpleInstrumentor.cs
+++ b/src/PerfIt/SimpleInstrumentor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace PerfIt
@@ -178,7 +179,9 @@ namespace PerfIt
 
         private void Prepare(List<PerfitHandlerContext> contexts)
         {
-            foreach (var handlerFactory in PerfItRuntime.HandlerFactories)
+            var counters = _info.Counters==null || _info.Counters.Length == 0 ? CounterTypes.StandardCounters : _info.Counters;
+
+            foreach (var handlerFactory in PerfItRuntime.HandlerFactories.Where(c=> counters.Contains(c.Key)))
             {
                 var key = GetKey(handlerFactory.Key, _info.InstanceName);
                 var ctx = _counterContexts.GetOrAdd(key, k =>

--- a/test/PerfIt.Tests/PerfIt.Tests.csproj
+++ b/test/PerfIt.Tests/PerfIt.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="PerfItRuntimeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleInstrumenterTests.cs" />
+    <Compile Include="Stubs\CustomCounterStub.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/test/PerfIt.Tests/Stubs/CustomCounterStub.cs
+++ b/test/PerfIt.Tests/Stubs/CustomCounterStub.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using PerfIt.Handlers;
+
+namespace PerfIt.Tests.Stubs
+{
+    public class CustomCounterStub : CounterHandlerBase
+    {
+        public static int RequestStartCount { get; private set; }
+        public static int RequestEndCount { get; private set; }
+
+        public static void ClearCounters()
+        {
+            RequestStartCount = 0;
+            RequestEndCount = 0;
+        }
+
+        public CustomCounterStub(string categoryName, string instanceName) : base(categoryName, instanceName)
+        {            
+        }
+
+        public override string CounterType { get; }
+        protected override void OnRequestStarting(IDictionary<string, object> contextBag, PerfItContext context)
+        {
+            RequestStartCount++;
+        }
+
+        protected override void OnRequestEnding(IDictionary<string, object> contextBag, PerfItContext context)
+        {
+            RequestEndCount++;
+        }
+
+        protected override void BuildCounters(bool newInstanceName = false)
+        {            
+        }
+
+        protected override CounterCreationData[] DoGetCreationData()
+        {
+            return new CounterCreationData[] {};
+        }
+    }
+}


### PR DESCRIPTION
When creating a custom performance counter and then registering the handler with PerfItRuntime.HandlerFactories, the new handler will be called for all instances of the SimpleInstrumentor, even if it isn't contained in the original counters property when the SimpleInstrumentor was instantiated.

I have added a simple test to prove the problem, and a fix for the issue.