### PR TITLE
Fix for intercepting async methods

### DIFF
--- a/src/PerfIt.Castle.Interception/PerfItInterceptor.cs
+++ b/src/PerfIt.Castle.Interception/PerfItInterceptor.cs
@@ -148,7 +148,7 @@ namespace PerfIt.Castle.Interception
                         instrumentor.InstrumentAsync(() =>
                         {
                             invocation.Proceed();
-                            return Task.FromResult(false);
+                            return (Task)invocation.ReturnValue;
                         }, instrumentationContext: instrumentationContext, samplingRate: SamplingRate);
                     }
                     else


### PR DESCRIPTION
Returning the task we are interested in rather than a manually created one. Now the processing time is measured correctly.