### PR TITLE
Default value of PublishErrors in WebApi

### DIFF
--- a/src/PerfIt.WebApi/PerfItFilterAttribute.cs
+++ b/src/PerfIt.WebApi/PerfItFilterAttribute.cs
@@ -21,7 +21,7 @@ namespace PerfIt.WebApi
         {
             Description = string.Empty;
             PublishCounters = true;
-            RaisePublishErrors = false;
+            RaisePublishErrors = true;
             PublishEvent = true;
             CategoryName = categoryName;
         }


### PR DESCRIPTION
According to documentation (https://github.com/aliostad/PerfIt#not-to-throw-publishing-errors) by default publishing errors should be thrown, but if perfit:publishErrors is not set, the default value will be false and errors will be swallowed.